### PR TITLE
Switch all tests to use the new 'test-scope' pseudo-command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,22 @@ install: build
 # Running legislation unit tests
 ################################
 
-pass_all_tests:
+test:
 	$(CLERK_TEST)
 
-reset_all_tests: CLERK_OPTS+=--reset
+TEST_FLAGS_LIST = "" --lcalc,--avoid-exceptions,-O
+
+testsuite: .FORCE
+	@for F in $(TEST_FLAGS_LIST); do \
+	  echo >&2; \
+	  [ -z "$$F" ] || echo ">> RE-RUNNING TESTS WITH FLAGS: $$F" >&2; \
+	  $(CLERK_TEST) --test-flags="$$F" || break; \
+	done
+
+pass_all_tests: testsuite
+
 reset_all_tests:
-	$(CLERK_TEST)
+	$(CLERK_TEST) --reset
 
 %.catala_en %.catala_fr %.catala_pl: .FORCE
 	$(CLERK_TEST) ./$@

--- a/NSW_community_gaming/tests/test_nsw_art_union.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_art_union.catala_en
@@ -25,7 +25,7 @@ scope Test1:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test1
+$ catala test-scope Test1
 [RESULT] Computation successful!
 ```
 
@@ -50,7 +50,7 @@ scope Test2:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test2
+$ catala test-scope Test2
 [RESULT] Computation successful!
 ```
 
@@ -76,7 +76,7 @@ scope Test3:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test3
+$ catala test-scope Test3
 [RESULT] Computation successful!
 ```
 
@@ -102,6 +102,6 @@ scope Test4:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test4
+$ catala test-scope Test4
 [RESULT] Computation successful!
 ```

--- a/NSW_community_gaming/tests/test_nsw_charity_housie.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_charity_housie.catala_en
@@ -27,7 +27,7 @@ scope Test1:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test1
+$ catala test-scope Test1
 [RESULT] Computation successful!
 ```
 
@@ -54,7 +54,7 @@ scope Test2:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test2
+$ catala test-scope Test2
 [RESULT] Computation successful!
 ```
 ## Test3
@@ -80,7 +80,7 @@ scope Test3:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test3
+$ catala test-scope Test3
 [RESULT] Computation successful!
 ```
 ## Test4
@@ -106,6 +106,6 @@ scope Test4:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test4
+$ catala test-scope Test4
 [RESULT] Computation successful!
 ```

--- a/NSW_community_gaming/tests/test_nsw_club_bingo.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_club_bingo.catala_en
@@ -26,7 +26,7 @@ scope Test1:
 
 
 ```catala-test-inline
-$ catala Interpret -s Test1
+$ catala test-scope Test1
 [RESULT] Computation successful!
 ```
 
@@ -52,7 +52,7 @@ scope Test2:
 
 
 ```catala-test-inline
-$ catala Interpret -s Test2
+$ catala test-scope Test2
 [RESULT] Computation successful!
 ```
 
@@ -77,7 +77,7 @@ scope Test3:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test3
+$ catala test-scope Test3
 [RESULT] Computation successful!
 ```
 
@@ -103,7 +103,7 @@ scope Test4:
 
 
 ```catala-test-inline
-$ catala Interpret -s Test4
+$ catala test-scope Test4
 [RESULT] Computation successful!
 ```
 
@@ -129,6 +129,6 @@ scope Test5:
 
 
 ```catala-test-inline
-$ catala Interpret -s Test5
+$ catala test-scope Test5
 [RESULT] Computation successful!
 ```

--- a/NSW_community_gaming/tests/test_nsw_draw_lottery.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_draw_lottery.catala_en
@@ -23,7 +23,7 @@ scope Test1:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test1
+$ catala test-scope Test1
 [RESULT] Computation successful!
 ```
 
@@ -47,7 +47,7 @@ scope Test2:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test2
+$ catala test-scope Test2
 [RESULT] Computation successful!
 ```
 
@@ -70,7 +70,7 @@ scope Test3:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test3
+$ catala test-scope Test3
 [RESULT] Computation successful!
 ```
 
@@ -93,6 +93,6 @@ scope Test4:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test4
+$ catala test-scope Test4
 [RESULT] Computation successful!
 ```

--- a/NSW_community_gaming/tests/test_nsw_no_draw_lottery.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_no_draw_lottery.catala_en
@@ -24,7 +24,7 @@ scope Test1:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test1
+$ catala test-scope Test1
 [RESULT] Computation successful!
 ```
 
@@ -49,7 +49,7 @@ scope Test2:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test2
+$ catala test-scope Test2
 [RESULT] Computation successful!
 ```
 
@@ -73,7 +73,7 @@ scope Test3:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test3
+$ catala test-scope Test3
 [RESULT] Computation successful!
 ```
 
@@ -97,6 +97,6 @@ scope Test4:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test4
+$ catala test-scope Test4
 [RESULT] Computation successful!
 ```

--- a/NSW_community_gaming/tests/test_nsw_progressive_lottery.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_progressive_lottery.catala_en
@@ -22,7 +22,7 @@ scope Test1:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test1
+$ catala test-scope Test1
 [RESULT] Computation successful!
 ```
 
@@ -45,7 +45,7 @@ declaration scope Test2:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test2
+$ catala test-scope Test2
 [RESULT] Computation successful!
 ```
 
@@ -68,7 +68,7 @@ declaration scope Test3:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test3
+$ catala test-scope Test3
 [RESULT] Computation successful!
 ```
 
@@ -89,7 +89,7 @@ declaration scope Test4:
   assertion my_gaming.authorized = false
 ```
 ```catala-test-inline
-$ catala Interpret -s Test4
+$ catala test-scope Test4
 [RESULT] Computation successful!
 ```
 

--- a/aides_logement/tests/tests_calcul_al_accession_propriete.catala_fr
+++ b/aides_logement/tests/tests_calcul_al_accession_propriete.catala_fr
@@ -79,26 +79,13 @@ $ catala Typecheck --check-invariants
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple1
+$ catala test-scope Exemple1
 [RESULT] Computation successful! Results:
 [RESULT] montant = 96,48 €
 ```
 
 ```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple1 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 96,48 €
-```
-
-```catala-test-inline
-$ catala Interpret -s Exemple2
+$ catala test-scope Exemple2
 [RESULT] Computation successful! Results:
 [RESULT] montant = 85,00 €
 ```
-
-```catala-test-inline
-$ catala Interpret_lcalc -s Exemple2 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 85,00 €
-```
-

--- a/aides_logement/tests/tests_calcul_al_locatif.catala_fr
+++ b/aides_logement/tests/tests_calcul_al_locatif.catala_fr
@@ -132,49 +132,25 @@ $ catala Typecheck --check-invariants
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple1 --disable-warnings
+$ catala test-scope Exemple1 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 345,73 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple2 --disable-warnings
+$ catala test-scope Exemple2 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 352,77 €
 ```
 
 ```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple1 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 345,73 €
-```
-
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple2 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 352,77 €
-```
-
-```catala-test-inline
-$ catala Interpret -s Exemple3 --disable-warnings
+$ catala test-scope Exemple3 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 339,70 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple4 --disable-warnings
-[RESULT] Computation successful! Results:
-[RESULT] montant = 230,63 €
-```
-
-```catala-test-inline
-$ catala Interpret_lcalc -s Exemple3 --disable-warnings --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 339,70 €
-```
-
-```catala-test-inline
-$ catala Interpret_lcalc -s Exemple4 --disable-warnings --avoid-exceptions
+$ catala test-scope Exemple4 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 230,63 €
 ```

--- a/aides_logement/tests/tests_calcul_al_logement_foyer.catala_fr
+++ b/aides_logement/tests/tests_calcul_al_logement_foyer.catala_fr
@@ -38,12 +38,7 @@ $ catala Typecheck --check-invariants
 ```
 
 ```catala-test-inline
-$ catala Interpret -s CasTest1 --disable-warnings
-[RESULT] Computation successful! Results:
-[RESULT] montant = 76,38 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s CasTest1 --avoid-exceptions
+$ catala test-scope CasTest1 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 76,38 €
 ```

--- a/aides_logement/tests/tests_calcul_apl_accession_propriete.catala_fr
+++ b/aides_logement/tests/tests_calcul_apl_accession_propriete.catala_fr
@@ -148,46 +148,26 @@ champ d'application Exemple4:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple1 --disable-warnings
+$ catala test-scope Exemple1 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 181,91 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple2 --disable-warnings
+$ catala test-scope Exemple2 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 67,34 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple3 --disable-warnings
+$ catala test-scope Exemple3 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 181,91 €
 ```
 
 
 ```catala-test-inline
-$ catala Interpret -s Exemple4 --disable-warnings
-[RESULT] Computation successful! Results:
-[RESULT] montant = 118,59 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple1 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 181,91 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple2 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 67,34 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple3 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 181,91 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple4 --avoid-exceptions
+$ catala test-scope Exemple4 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 118,59 €
 ```

--- a/aides_logement/tests/tests_calcul_apl_locatif.catala_fr
+++ b/aides_logement/tests/tests_calcul_apl_locatif.catala_fr
@@ -279,100 +279,55 @@ champ d'application Exemple9:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple1 --disable-warnings
+$ catala test-scope Exemple1 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 0,00 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple2 --disable-warnings
+$ catala test-scope Exemple2 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 352,77 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple3 --disable-warnings
+$ catala test-scope Exemple3 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 321,61 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple4 --disable-warnings
+$ catala test-scope Exemple4 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 0,00 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple5 --disable-warnings
+$ catala test-scope Exemple5 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 311,56 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple6 --disable-warnings
+$ catala test-scope Exemple6 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 0,00 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple7 --disable-warnings
+$ catala test-scope Exemple7 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 153,77 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple8 --disable-warnings
+$ catala test-scope Exemple8 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 11,06 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple9 --disable-warnings
-[RESULT] Computation successful! Results:
-[RESULT] montant = 210,06 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple1 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 0,00 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple2 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 352,77 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple3 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 321,61 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple4 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 0,00 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple5 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 311,56 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple6 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 0,00 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple7 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 153,77 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple8 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 11,06 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple9 --avoid-exceptions
+$ catala test-scope Exemple9 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 210,06 €
 ```

--- a/aides_logement/tests/tests_calcul_apl_logement_foyer.catala_fr
+++ b/aides_logement/tests/tests_calcul_apl_logement_foyer.catala_fr
@@ -137,56 +137,31 @@ champ d'application CasTest5:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s CasTest1 --disable-warnings
+$ catala test-scope CasTest1 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 12,06 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s CasTest2 --disable-warnings
+$ catala test-scope CasTest2 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 23,12 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s CasTest3 --disable-warnings
+$ catala test-scope CasTest3 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 154,78 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s CasTest4 --disable-warnings
+$ catala test-scope CasTest4 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 154,78 €
 ```
 
 ```catala-test-inline
-$ catala Interpret -s CasTest5 --disable-warnings
-[RESULT] Computation successful! Results:
-[RESULT] montant = 129,65 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s CasTest1 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 12,06 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s CasTest2 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 23,12 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s CasTest3 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 154,78 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s CasTest4 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant = 154,78 €
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s CasTest5 --avoid-exceptions
+$ catala test-scope CasTest5 --disable-warnings
 [RESULT] Computation successful! Results:
 [RESULT] montant = 129,65 €
 ```

--- a/aides_logement/tests/tests_calculette_globale.catala_fr
+++ b/aides_logement/tests/tests_calculette_globale.catala_fr
@@ -156,41 +156,14 @@ champ d'application Exemple2 :
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple1
-[RESULT] Computation successful! Results:
-[RESULT] montant_versé = 246,23 €
-[RESULT] éligibilité = vrai
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple1 --avoid-exceptions
+$ catala test-scope Exemple1
 [RESULT] Computation successful! Results:
 [RESULT] montant_versé = 246,23 €
 [RESULT] éligibilité = vrai
 ```
 
 ```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple1 --avoid-exceptions -O --closure-conversion
-[RESULT] Computation successful! Results:
-[RESULT] montant_versé = 246,23 €
-[RESULT] éligibilité = vrai
-```
-
-```catala-test-inline
-$ catala Interpret -s Exemple2
-[RESULT] Computation successful! Results:
-[RESULT] montant_versé = 230,63 €
-[RESULT] éligibilité = vrai
-```
-
-```catala-test-inline
-$ catala Interpret_lcalc -s Exemple2 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] montant_versé = 230,63 €
-[RESULT] éligibilité = vrai
-```
-
-```catala-test-inline
-$ catala Interpret_lcalc -s Exemple2 -O --avoid-exceptions --closure-conversion
+$ catala test-scope Exemple2
 [RESULT] Computation successful! Results:
 [RESULT] montant_versé = 230,63 €
 [RESULT] éligibilité = vrai

--- a/aides_logement/tests/tests_eligibilite_apl.catala_fr
+++ b/aides_logement/tests/tests_eligibilite_apl.catala_fr
@@ -213,45 +213,24 @@ champ d'application Exemple3 :
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Exemple1 --disable-warnings
-[RESULT] Computation successful! Results:
-[RESULT] éligible = vrai
-```
-
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple1 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] éligible = vrai
-```
-
-
-```catala-test-inline
-$ catala Interpret -s Exemple2 --disable-warnings
-[RESULT] Computation successful! Results:
-[RESULT] éligible = AllocationLogementFamiliale ()
-```
-
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple2 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] éligible = AllocationLogementFamiliale ()
-```
-
-
-```catala-test-inline
-$ catala Interpret -s Exemple3 --disable-warnings
-[RESULT] Computation successful! Results:
-[RESULT] éligible = AllocationLogementFamiliale ()
-```
-
-```catala-test-inline
-$ catala Interpret_Lcalc -s Exemple3 --avoid-exceptions
-[RESULT] Computation successful! Results:
-[RESULT] éligible = AllocationLogementFamiliale ()
-```
-
-```catala-test-inline
 $ catala Typecheck
 [RESULT] Typechecking successful!
 ```
 
+```catala-test-inline
+$ catala test-scope Exemple1 --disable-warnings
+[RESULT] Computation successful! Results:
+[RESULT] éligible = vrai
+```
+
+```catala-test-inline
+$ catala test-scope Exemple2 --disable-warnings
+[RESULT] Computation successful! Results:
+[RESULT] éligible = AllocationLogementFamiliale ()
+```
+
+```catala-test-inline
+$ catala test-scope Exemple3 --disable-warnings
+[RESULT] Computation successful! Results:
+[RESULT] éligible = AllocationLogementFamiliale ()
+```

--- a/allocations_familiales/tests/tests_allocations_familiales.catala_fr
+++ b/allocations_familiales/tests/tests_allocations_familiales.catala_fr
@@ -354,127 +354,71 @@ $ catala Typecheck
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test1 --disable-warnings
+$ catala test-scope Test1 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test2 --disable-warnings
+$ catala test-scope Test2 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test3 --disable-warnings
+$ catala test-scope Test3 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test4 --disable-warnings
+$ catala test-scope Test4 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test5 --disable-warnings
+$ catala test-scope Test5 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test6 --disable-warnings
+$ catala test-scope Test6 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test7 --disable-warnings
+$ catala test-scope Test7 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test8 --disable-warnings
+$ catala test-scope Test8 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test9 --disable-warnings
+$ catala test-scope Test9 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test10 --disable-warnings
+$ catala test-scope Test10 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test11 --disable-warnings
+$ catala test-scope Test11 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test12 --disable-warnings
+$ catala test-scope Test12 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test13 --disable-warnings
+$ catala test-scope Test13 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test13 --disable-warnings
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test1 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test2 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test3 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test4 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test5 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test6 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test7 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test8 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test9 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test10 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test11 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test12 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test13 --avoid-exceptions
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test13 --avoid-exceptions
+$ catala test-scope Test13 --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/allocations_familiales/tests/tests_ouverture_droits.catala_fr
+++ b/allocations_familiales/tests/tests_ouverture_droits.catala_fr
@@ -61,10 +61,6 @@ champ d'application Test1:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test1 --disable-warnings
-[RESULT] Computation successful!
-```
-```catala-test-inline
-$ catala Interpret_Lcalc -s Test1 --avoid-exceptions
+$ catala test-scope Test1 --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/droit_successions/tests/tests_droit_succession.catala_fr
+++ b/droit_successions/tests/tests_droit_succession.catala_fr
@@ -68,21 +68,21 @@ champ d'application Test4:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test1
+$ catala test-scope Test1
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test2
+$ catala test-scope Test2
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test3
+$ catala test-scope Test3
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test4
+$ catala test-scope Test4
 [RESULT] Computation successful!
 ```

--- a/polish_taxes/tests/test_a7_u1_p1.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p1.catala_pl
@@ -23,11 +23,11 @@ zakres Test_A7_U1_P1_PPb:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test_A7_U1_P1_PPa --disable-warnings
+$ catala test-scope Test_A7_U1_P1_PPa --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test_A7_U1_P1_PPb --disable-warnings
+$ catala test-scope Test_A7_U1_P1_PPb --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/polish_taxes/tests/test_a7_u1_p2.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p2.catala_pl
@@ -23,11 +23,11 @@ zakres Test_A7_U1_P2_PPb:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test_A7_U1_P2_PPa --disable-warnings
+$ catala test-scope Test_A7_U1_P2_PPa --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test_A7_U1_P2_PPb --disable-warnings
+$ catala test-scope Test_A7_U1_P2_PPb --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/polish_taxes/tests/test_a7_u1_p3.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p3.catala_pl
@@ -12,6 +12,6 @@ zakres Test_A7_U1_P3:
   asercja sprzedaż.podatek = 1 PLN
 ```
 ```catala-test-inline
-$ catala Interpret -s Test_A7_U1_P3 --disable-warnings
+$ catala test-scope Test_A7_U1_P3 --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/polish_taxes/tests/test_a7_u1_p4.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p4.catala_pl
@@ -12,6 +12,6 @@ zakres Test_A7_U1_P4:
   asercja sprzedaż.podatek = 1 PLN
 ```
 ```catala-test-inline
-$ catala Interpret -s Test_A7_U1_P4 --disable-warnings
+$ catala test-scope Test_A7_U1_P4 --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/polish_taxes/tests/test_a7_u1_p7.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p7.catala_pl
@@ -12,6 +12,6 @@ zakres Test_A7_U1_P7:
   asercja sprzedaż.podatek = 1 PLN
 ```
 ```catala-test-inline
-$ catala Interpret -s Test_A7_U1_P7 --disable-warnings
+$ catala test-scope Test_A7_U1_P7 --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/polish_taxes/tests/test_a7_u1_p9.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p9.catala_pl
@@ -12,6 +12,6 @@ zakres Test_A7_U1_P9:
   asercja sprzedaż.podatek = 5 PLN
 ```
 ```catala-test-inline
-$ catala Interpret -s Test_A7_U1_P9 --disable-warnings
+$ catala test-scope Test_A7_U1_P9 --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/prestations_familiales/tests/tests_ouverture_droits.catala_fr
+++ b/prestations_familiales/tests/tests_ouverture_droits.catala_fr
@@ -53,6 +53,6 @@ champ d'application Test1:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test1 --disable-warnings
+$ catala test-scope Test1 --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/tutorial_en/tests/test_tutorial.catala_en
+++ b/tutorial_en/tests/test_tutorial.catala_en
@@ -29,11 +29,11 @@ scope UnitTest2:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s UnitTest1 --disable-warnings
+$ catala test-scope UnitTest1 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s UnitTest2 --disable-warnings
+$ catala test-scope UnitTest2 --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/tutoriel_fr/tests/test_tutoriel.catala_fr
+++ b/tutoriel_fr/tests/test_tutoriel.catala_fr
@@ -29,11 +29,11 @@ champ d'application TestUnitaire2:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s TestUnitaire1 --disable-warnings
+$ catala test-scope TestUnitaire1 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s TestUnitaire2 --disable-warnings
+$ catala test-scope TestUnitaire2 --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/us_tax_code/tests/test_section_121.catala_en
+++ b/us_tax_code/tests/test_section_121.catala_en
@@ -146,31 +146,31 @@ scope Test6:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test1 --disable-warnings
+$ catala test-scope Test1 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test2 --disable-warnings
+$ catala test-scope Test2 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test3 --disable-warnings
+$ catala test-scope Test3 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test4 --disable-warnings
+$ catala test-scope Test4 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test5 --disable-warnings
+$ catala test-scope Test5 --disable-warnings
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Test6 --disable-warnings
+$ catala test-scope Test6 --disable-warnings
 [RESULT] Computation successful!
 ```

--- a/us_tax_code/tests/test_section_132.catala_en
+++ b/us_tax_code/tests/test_section_132.catala_en
@@ -43,16 +43,16 @@ scope TestSection132_3:
 ```
 
 ```catala-test-inline
-$ catala Interpret -s TestSection132_1
+$ catala test-scope TestSection132_1
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s TestSection132_2
+$ catala test-scope TestSection132_2
 [RESULT] Computation successful!
 ```
 
 ```catala-test-inline
-$ catala Interpret -s TestSection132_3
+$ catala test-scope TestSection132_3
 [RESULT] Computation successful!
 ```


### PR DESCRIPTION
This allows to remove the duplicate test outputs for `interpret` and `interpret_lcalc --avoid-exceptions`.

NOTE: breaking, should be merged in sync with https://github.com/CatalaLang/catala/pull/584