### PR TITLE
Fix links in tutorials

### DIFF
--- a/tutorial_en/tutorial_en.catala_en
+++ b/tutorial_en/tutorial_en.catala_en
@@ -19,10 +19,10 @@ things out.
 # and start typing your program.
 
 # For a complete reference of the Catala syntax, see:
-# https://github.com/CatalaLang/catala/raw/master/doc/syntax/syntax.pdf
+# https://catalalang.github.io/catala/syntax.pdf
 
 # This tutorial itself is written as a Catala program and can be accessed at:
-# https://github.com/CatalaLang/catala/blob/master/examples/tutorial_en
+# https://github.com/CatalaLang/catala-examples/tree/master/tutorial_en
 ```
 
 ## Literate programming

--- a/tutoriel_fr/tutoriel_fr.catala_fr
+++ b/tutoriel_fr/tutoriel_fr.catala_fr
@@ -24,10 +24,10 @@ des compétences en informatique devraient pouvoir s’en sortir.
 # et commencez à taper votre programme.
 
 # Pour une référence complète de la syntaxe Catala, voyez sur :
-# https://github.com/CatalaLang/catala/raw/master/doc/syntax/syntax.pdf
+# https://catalalang.github.io/catala/syntax.pdf
 
 # Ce tutoriel est lui-même écrit comme un programme Catala et est accessible à :
-# https://github.com/CatalaLang/catala/blob/master/examples/tutoriel_fr
+# https://github.com/CatalaLang/catala-examples/tree/master/tutoriel_fr
 ```
 
 ## Programmation littéraire


### PR DESCRIPTION
This commit updates the links in the English and French tutorial to the Catala syntax doc and the tutorial source code, which were invalidated in https://github.com/CatalaLang/catala/commit/71e3ca21c09c345e94b48873dc52543c368edf79 and https://github.com/CatalaLang/catala/commit/acdaf7c57df3e46dc24b687c06035d7c122551b9 respectively.