### PR TITLE
Remove obsolete --avoid-exceptions flag from tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ binary-tests: \
 test: .FORCE binary-tests
 	$(CLERK_TEST)
 
-TEST_FLAGS_LIST = "" --lcalc,--avoid-exceptions,-O
+TEST_FLAGS_LIST = "" --lcalc,--closure-conversion,-O
 
 testsuite: .FORCE binary-tests
 	@for F in $(TEST_FLAGS_LIST); do \


### PR DESCRIPTION
and replace it with a test with closure conversion enabled

Related to https://github.com/CatalaLang/catala/pull/641