### PR TITLE
add devcontainer and codespaces badge

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM docker.io/ocaml/opam:debian-12-ocaml-5.0
+
+USER root
+
+RUN apt-get update && apt-get install -y git ca-certificates libgmp-dev pkg-config ninja-build openjdk-17-jdk && rm -rf /var/lib/apt/lists/*
+
+USER opam
+
+RUN opam pin catala-lsp.dev git+https://github.com/CatalaLang/catala-language-server -y
+
+CMD ["/bin/bash"]
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "build": { "dockerfile": "Dockerfile" },
+  "customizations": {
+    "vscode": {
+      "extensions": ["catalalang.catala"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ of the Catala programming language development.
 
 <strong>[Browse examples online »](https://catala-lang.org/en/examples)</strong>
 
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/CatalaLang/catala-examples?quickstart=1)
+
 ## List of examples
 
 - `allocations_familiales/`: computation of the French family benefits, based


### PR DESCRIPTION
A codespace for the catala-examples project (aimed at teaching / trying out catala, so we package the catala toolchain in the parent container vs build it at container start time e.g. in https://github.com/CatalaLang/catala-language-server/pull/119

It would be nice to have catala-format as well, but pinning catala-format (even supplying `-y`) in non interactive mode does not seem to install the rust toolchain?