### PR TITLE
Adjust CLI test outputs for change in catala

### DIFF
--- a/NSW_community_gaming/tests/test_nsw_art_union.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_art_union.catala_en
@@ -27,7 +27,7 @@ scope Test1:
 
 ```catala-test-cli
 $ catala test-scope Test1
-┌─[RESULT]─
+┌─[RESULT]─ Test1 ─
 │ Computation successful!
 └─
 ```
@@ -55,7 +55,7 @@ scope Test2:
 
 ```catala-test-cli
 $ catala test-scope Test2
-┌─[RESULT]─
+┌─[RESULT]─ Test2 ─
 │ Computation successful!
 └─
 ```
@@ -83,7 +83,7 @@ scope Test3:
 
 ```catala-test-cli
 $ catala test-scope Test3
-┌─[RESULT]─
+┌─[RESULT]─ Test3 ─
 │ Computation successful!
 └─
 ```
@@ -111,7 +111,7 @@ scope Test4:
 
 ```catala-test-cli
 $ catala test-scope Test4
-┌─[RESULT]─
+┌─[RESULT]─ Test4 ─
 │ Computation successful!
 └─
 ```

--- a/NSW_community_gaming/tests/test_nsw_charity_housie.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_charity_housie.catala_en
@@ -29,7 +29,7 @@ scope Test1:
 
 ```catala-test-cli
 $ catala test-scope Test1
-┌─[RESULT]─
+┌─[RESULT]─ Test1 ─
 │ Computation successful!
 └─
 ```
@@ -59,7 +59,7 @@ scope Test2:
 
 ```catala-test-cli
 $ catala test-scope Test2
-┌─[RESULT]─
+┌─[RESULT]─ Test2 ─
 │ Computation successful!
 └─
 ```
@@ -88,7 +88,7 @@ scope Test3:
 
 ```catala-test-cli
 $ catala test-scope Test3
-┌─[RESULT]─
+┌─[RESULT]─ Test3 ─
 │ Computation successful!
 └─
 ```
@@ -117,7 +117,7 @@ scope Test4:
 
 ```catala-test-cli
 $ catala test-scope Test4
-┌─[RESULT]─
+┌─[RESULT]─ Test4 ─
 │ Computation successful!
 └─
 ```

--- a/NSW_community_gaming/tests/test_nsw_club_bingo.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_club_bingo.catala_en
@@ -27,7 +27,7 @@ scope Test1:
 
 ```catala-test-cli
 $ catala test-scope Test1
-┌─[RESULT]─
+┌─[RESULT]─ Test1 ─
 │ Computation successful!
 └─
 ```
@@ -55,7 +55,7 @@ scope Test2:
 
 ```catala-test-cli
 $ catala test-scope Test2
-┌─[RESULT]─
+┌─[RESULT]─ Test2 ─
 │ Computation successful!
 └─
 ```
@@ -83,7 +83,7 @@ scope Test3:
 
 ```catala-test-cli
 $ catala test-scope Test3
-┌─[RESULT]─
+┌─[RESULT]─ Test3 ─
 │ Computation successful!
 └─
 ```
@@ -111,7 +111,7 @@ scope Test4:
 
 ```catala-test-cli
 $ catala test-scope Test4
-┌─[RESULT]─
+┌─[RESULT]─ Test4 ─
 │ Computation successful!
 └─
 ```
@@ -139,7 +139,7 @@ scope Test5:
 
 ```catala-test-cli
 $ catala test-scope Test5
-┌─[RESULT]─
+┌─[RESULT]─ Test5 ─
 │ Computation successful!
 └─
 ```

--- a/NSW_community_gaming/tests/test_nsw_draw_lottery.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_draw_lottery.catala_en
@@ -25,7 +25,7 @@ scope Test1:
 
 ```catala-test-cli
 $ catala test-scope Test1
-┌─[RESULT]─
+┌─[RESULT]─ Test1 ─
 │ Computation successful!
 └─
 ```
@@ -51,7 +51,7 @@ scope Test2:
 
 ```catala-test-cli
 $ catala test-scope Test2
-┌─[RESULT]─
+┌─[RESULT]─ Test2 ─
 │ Computation successful!
 └─
 ```
@@ -77,7 +77,7 @@ scope Test3:
 
 ```catala-test-cli
 $ catala test-scope Test3
-┌─[RESULT]─
+┌─[RESULT]─ Test3 ─
 │ Computation successful!
 └─
 ```
@@ -103,7 +103,7 @@ scope Test4:
 
 ```catala-test-cli
 $ catala test-scope Test4
-┌─[RESULT]─
+┌─[RESULT]─ Test4 ─
 │ Computation successful!
 └─
 ```

--- a/NSW_community_gaming/tests/test_nsw_no_draw_lottery.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_no_draw_lottery.catala_en
@@ -26,7 +26,7 @@ scope Test1:
 
 ```catala-test-cli
 $ catala test-scope Test1
-┌─[RESULT]─
+┌─[RESULT]─ Test1 ─
 │ Computation successful!
 └─
 ```
@@ -53,7 +53,7 @@ scope Test2:
 
 ```catala-test-cli
 $ catala test-scope Test2
-┌─[RESULT]─
+┌─[RESULT]─ Test2 ─
 │ Computation successful!
 └─
 ```
@@ -80,7 +80,7 @@ scope Test3:
 
 ```catala-test-cli
 $ catala test-scope Test3
-┌─[RESULT]─
+┌─[RESULT]─ Test3 ─
 │ Computation successful!
 └─
 ```
@@ -107,7 +107,7 @@ scope Test4:
 
 ```catala-test-cli
 $ catala test-scope Test4
-┌─[RESULT]─
+┌─[RESULT]─ Test4 ─
 │ Computation successful!
 └─
 ```

--- a/NSW_community_gaming/tests/test_nsw_progressive_lottery.catala_en
+++ b/NSW_community_gaming/tests/test_nsw_progressive_lottery.catala_en
@@ -24,7 +24,7 @@ scope Test1:
 
 ```catala-test-cli
 $ catala test-scope Test1
-┌─[RESULT]─
+┌─[RESULT]─ Test1 ─
 │ Computation successful!
 └─
 ```
@@ -49,7 +49,7 @@ scope Test2:
 
 ```catala-test-cli
 $ catala test-scope Test2
-┌─[RESULT]─
+┌─[RESULT]─ Test2 ─
 │ Computation successful!
 └─
 ```
@@ -74,7 +74,7 @@ scope Test3:
 
 ```catala-test-cli
 $ catala test-scope Test3
-┌─[RESULT]─
+┌─[RESULT]─ Test3 ─
 │ Computation successful!
 └─
 ```
@@ -98,7 +98,7 @@ scope Test4:
 ```
 ```catala-test-cli
 $ catala test-scope Test4
-┌─[RESULT]─
+┌─[RESULT]─ Test4 ─
 │ Computation successful!
 └─
 ```

--- a/allocations_familiales/tests/tests_allocations_familiales.catala_fr
+++ b/allocations_familiales/tests/tests_allocations_familiales.catala_fr
@@ -406,98 +406,98 @@ $ catala Typecheck
 
 ```catala-test-cli
 $ catala test-scope Test1 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test1 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test2 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test2 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test3 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test3 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test4 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test4 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test5 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test5 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test6 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test6 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test7 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test7 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test8 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test8 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test9 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test9 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test10 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test10 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test11 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test11 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test12 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test12 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test13 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test13 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test13 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test13 ─
 │ Computation successful!
 └─
 ```

--- a/allocations_familiales/tests/tests_ouverture_droits.catala_fr
+++ b/allocations_familiales/tests/tests_ouverture_droits.catala_fr
@@ -69,7 +69,7 @@ champ d'application Test1:
 
 ```catala-test-cli
 $ catala test-scope Test1 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test1 ─
 │ Computation successful!
 └─
 ```

--- a/droit_successions/tests/tests_droit_succession.catala_fr
+++ b/droit_successions/tests/tests_droit_succession.catala_fr
@@ -73,28 +73,28 @@ champ d'application Test4:
 
 ```catala-test-cli
 $ catala test-scope Test1
-┌─[RESULT]─
+┌─[RESULT]─ Test1 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test2
-┌─[RESULT]─
+┌─[RESULT]─ Test2 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test3
-┌─[RESULT]─
+┌─[RESULT]─ Test3 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test4
-┌─[RESULT]─
+┌─[RESULT]─ Test4 ─
 │ Computation successful!
 └─
 ```

--- a/polish_taxes/tests/test_a7_u1_p1.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p1.catala_pl
@@ -25,14 +25,14 @@ zakres Test_A7_U1_P1_PPb:
 
 ```catala-test-cli
 $ catala test-scope Test_A7_U1_P1_PPa --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test_A7_U1_P1_PPa ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test_A7_U1_P1_PPb --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test_A7_U1_P1_PPb ─
 │ Computation successful!
 └─
 ```

--- a/polish_taxes/tests/test_a7_u1_p2.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p2.catala_pl
@@ -25,14 +25,14 @@ zakres Test_A7_U1_P2_PPb:
 
 ```catala-test-cli
 $ catala test-scope Test_A7_U1_P2_PPa --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test_A7_U1_P2_PPa ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test_A7_U1_P2_PPb --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test_A7_U1_P2_PPb ─
 │ Computation successful!
 └─
 ```

--- a/polish_taxes/tests/test_a7_u1_p3.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p3.catala_pl
@@ -14,7 +14,7 @@ zakres Test_A7_U1_P3:
 ```
 ```catala-test-cli
 $ catala test-scope Test_A7_U1_P3 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test_A7_U1_P3 ─
 │ Computation successful!
 └─
 ```

--- a/polish_taxes/tests/test_a7_u1_p4.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p4.catala_pl
@@ -14,7 +14,7 @@ zakres Test_A7_U1_P4:
 ```
 ```catala-test-cli
 $ catala test-scope Test_A7_U1_P4 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test_A7_U1_P4 ─
 │ Computation successful!
 └─
 ```

--- a/polish_taxes/tests/test_a7_u1_p7.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p7.catala_pl
@@ -14,7 +14,7 @@ zakres Test_A7_U1_P7:
 ```
 ```catala-test-cli
 $ catala test-scope Test_A7_U1_P7 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test_A7_U1_P7 ─
 │ Computation successful!
 └─
 ```

--- a/polish_taxes/tests/test_a7_u1_p9.catala_pl
+++ b/polish_taxes/tests/test_a7_u1_p9.catala_pl
@@ -14,7 +14,7 @@ zakres Test_A7_U1_P9:
 ```
 ```catala-test-cli
 $ catala test-scope Test_A7_U1_P9 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test_A7_U1_P9 ─
 │ Computation successful!
 └─
 ```

--- a/prestations_familiales/tests/tests_ouverture_droits.catala_fr
+++ b/prestations_familiales/tests/tests_ouverture_droits.catala_fr
@@ -60,7 +60,7 @@ champ d'application Test1:
 
 ```catala-test-cli
 $ catala test-scope Test1 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test1 ─
 │ Computation successful!
 └─
 ```

--- a/us_tax_code/tests/test_section_121.catala_en
+++ b/us_tax_code/tests/test_section_121.catala_en
@@ -160,42 +160,42 @@ scope Test6:
 
 ```catala-test-cli
 $ catala test-scope Test1 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test1 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test2 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test2 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test3 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test3 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test4 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test4 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test5 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test5 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope Test6 --disable-warnings
-┌─[RESULT]─
+┌─[RESULT]─ Test6 ─
 │ Computation successful!
 └─
 ```

--- a/us_tax_code/tests/test_section_132.catala_en
+++ b/us_tax_code/tests/test_section_132.catala_en
@@ -47,21 +47,21 @@ scope TestSection132_3:
 
 ```catala-test-cli
 $ catala test-scope TestSection132_1
-┌─[RESULT]─
+┌─[RESULT]─ TestSection132_1 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope TestSection132_2
-┌─[RESULT]─
+┌─[RESULT]─ TestSection132_2 ─
 │ Computation successful!
 └─
 ```
 
 ```catala-test-cli
 $ catala test-scope TestSection132_3
-┌─[RESULT]─
+┌─[RESULT]─ TestSection132_3 ─
 │ Computation successful!
 └─
 ```


### PR DESCRIPTION
the scope names are now printed on test success, even when there is no output

Sister PR: catala#1067