### PR TITLE
[APL] Corrige la précision du rapport de loyers

### DIFF
--- a/aides_logement/archives.catala_fr
+++ b/aides_logement/archives.catala_fr
@@ -423,7 +423,8 @@ RL est exprimé en pourcentage et arrondi à la deuxième décimale.
 champ d'application CalculAidePersonnaliséeLogementLocatif
 sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
   définition rapport_loyers égal à
-    arrondi de ((loyer_éligible / loyer_référence) * 100,0) / 100,0
+    # La deuxième décimale en pourcentage est la quatrième décimale du rapport
+    arrondi de ((loyer_éligible / loyer_référence) * 10000,0) / 10000,0
 ```
 
 Pour la détermination de TL , les taux progressifs et les tranches successives de RL mentionnés
@@ -2483,7 +2484,8 @@ RL est exprimé en pourcentage et arrondi à la deuxième décimale.
 champ d'application CalculAidePersonnaliséeLogementLocatif
 sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
   définition rapport_loyers égal à
-    arrondi de ((loyer_éligible / loyer_référence) * 100,0) / 100,0
+    # La deuxième décimale en pourcentage est la quatrième décimale du rapport
+    arrondi de ((loyer_éligible / loyer_référence) * 10000,0) / 10000,0
 ```
 
 Pour la détermination de TL , les taux progressifs et les tranches successives de RL mentionnés
@@ -4493,7 +4495,8 @@ sous condition
   date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
   définition rapport_loyers égal à
-    arrondi de ((loyer_éligible / loyer_référence) * 100,0) / 100,0
+    # La deuxième décimale en pourcentage est la quatrième décimale du rapport
+    arrondi de ((loyer_éligible / loyer_référence) * 10000,0) / 10000,0
 ```
 
 Pour la détermination de TL , les taux progressifs et les tranches successives de RL mentionnés
@@ -5710,7 +5713,8 @@ sous condition
   date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
   définition rapport_loyers égal à
-    arrondi de ((loyer_éligible / loyer_référence) * 100,0) / 100,0
+    # La deuxième décimale en pourcentage est la quatrième décimale du rapport
+    arrondi de ((loyer_éligible / loyer_référence) * 10000,0) / 10000,0
 ```
 
 Pour la détermination de TL , les taux progressifs et les tranches successives de RL mentionnés
@@ -7791,7 +7795,8 @@ RL est exprimé en pourcentage et arrondi à la deuxième décimale.
 champ d'application CalculAidePersonnaliséeLogementLocatif
 sous condition date_courante >= |2024-10-01| et date_courante < |2025-10-01|:
   définition rapport_loyers égal à
-    arrondi de ((loyer_éligible / loyer_référence) * 100,0) / 100,0
+    # La deuxième décimale en pourcentage est la quatrième décimale du rapport
+    arrondi de ((loyer_éligible / loyer_référence) * 10000,0) / 10000,0
 ```
 
 Pour la détermination de TL , les taux progressifs et les tranches successives de RL mentionnés

--- a/aides_logement/arrete_2019-09-27.catala_fr
+++ b/aides_logement/arrete_2019-09-27.catala_fr
@@ -408,7 +408,8 @@ RL est exprimé en pourcentage et arrondi à la deuxième décimale.
 champ d'application CalculAidePersonnaliséeLogementLocatif
 sous condition date_courante >= |2025-10-01|:
   définition rapport_loyers égal à
-    arrondi de ((loyer_éligible / loyer_référence) * 100,0) / 100,0
+    # La deuxième décimale en pourcentage est la quatrième décimale du rapport
+    arrondi de ((loyer_éligible / loyer_référence) * 10000,0) / 10000,0
 ```
 
 Pour la détermination de TL , les taux progressifs et les tranches successives de RL mentionnés

--- a/aides_logement/tests/tests_calcul_apl_locatif.catala_fr
+++ b/aides_logement/tests/tests_calcul_apl_locatif.catala_fr
@@ -33,7 +33,7 @@ champ d'application Exemple1:
   assertion calcul.plafond_loyer_d823_16_2 = 524,20 €
   assertion calcul.participation_minimale = 52,30 €
   assertion calcul.taux_composition_familiale = 2,01%
-  assertion calcul.participation_personnelle = 713,25 €
+  assertion calcul.participation_personnelle = 714,35 €
 ```
 
 ```catala
@@ -99,7 +99,7 @@ champ d'application Exemple3:
   assertion calcul.plafond_loyer_d823_16_2 = 425,80 €
   assertion calcul.participation_minimale = 42,42 €
   assertion calcul.taux_composition_familiale = 2,01%
-  assertion calcul.participation_personnelle = 172,05 €
+  assertion calcul.participation_personnelle = 172,22 €
 ```
 
 ```catala
@@ -132,7 +132,7 @@ champ d'application Exemple4:
   assertion calcul.plafond_loyer_d823_16_2 = 406,30 €
   assertion calcul.participation_minimale = 40,19€
   assertion calcul.taux_composition_familiale = 2,70%
-  assertion calcul.participation_personnelle = 1016,63 €
+  assertion calcul.participation_personnelle = 1015,68 €
 ```
 
 ```catala
@@ -231,7 +231,7 @@ champ d'application Exemple7:
   assertion calcul.plafond_loyer_d823_16_2 = 618,20 €
   assertion calcul.participation_minimale = 55,67 €
   assertion calcul.taux_composition_familiale = 1,73%
-  assertion calcul.participation_personnelle = 495,64 €
+  assertion calcul.participation_personnelle = 496,10 €
 ```
 
 ```catala
@@ -264,7 +264,7 @@ champ d'application Exemple8:
   assertion calcul.plafond_loyer_d823_16_2 = 268,26 €
   assertion calcul.participation_minimale = 35,39 €
   assertion calcul.taux_composition_familiale = 3,15%
-  assertion calcul.participation_personnelle = 306,11 €
+  assertion calcul.participation_personnelle = 306,36 €
 ```
 
 ```catala
@@ -295,7 +295,7 @@ champ d'application Exemple9:
   définition calcul.bénéficiaire_aide_adulte_ou_enfant_handicapés égal à faux
   définition calcul.logement_meublé_d842_2 égal à faux
   définition calcul.résidence égal à Métropole
-  assertion montant = 210,06 €
+  assertion montant = 211,06 €
 ```
 
 ```catala-test-cli
@@ -357,6 +357,6 @@ $ catala test-scope Exemple8 --disable-warnings
 ```catala-test-cli
 $ catala test-scope Exemple9 --disable-warnings
 ┌─[RESULT]─ Exemple9 ─
-│ montant = 210,06 €
+│ montant = 211,06 €
 └─
 ```

--- a/aides_logement/tests/tests_calculette_globale.catala_fr
+++ b/aides_logement/tests/tests_calculette_globale.catala_fr
@@ -196,7 +196,7 @@ champ d'application Exemple2:
 $ catala test-scope Exemple1
 ┌─[RESULT]─ Exemple1 ─
 │ éligibilité = vrai
-│ montant_versé = 246,23 €
+│ montant_versé = 245,23 €
 └─
 ```
 


### PR DESCRIPTION
## Description

Cette PR corrige l’arrondi du rapport de loyers `RL`.

`RL` est exprimé en pourcentage et doit être arrondi à la deuxième décimale du pourcentage. Il faut donc conserver quatre décimales sur le rapport avant le calcul de `TL`.

La formule :

`arrondi de (RL * 100) / 100`

est remplacée par :

`arrondi de (RL * 10000) / 10000`

La correction est appliquée aux six périodes concernées depuis octobre 2020.

## Références juridiques

L’article 14 de l’arrêté du 27 septembre 2019 précise que `RL` est exprimé en pourcentage et arrondi à la deuxième décimale :

- [Version en vigueur](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000052233852)
- [Octobre 2024](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286630)
- [Octobre 2023](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000048109301)
- [Juillet 2022](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046206208)
- [Octobre 2021](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000044137420)
- [Octobre 2020](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000042378440)