### PR TITLE
[APL] Corrige le R0 à Saint-Pierre-et-Miquelon en 2022

### DIFF
--- a/aides_logement/archives.catala_fr
+++ b/aides_logement/archives.catala_fr
@@ -3575,7 +3575,7 @@ sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
     sinon si nombre_personnes_à_charge = 6 alors
       9 816 €
     sinon
-      9 816 € + 350 € * (décimal de (nombre_personnes_à_charge - 6))
+      9 816 € + 323 € * (décimal de (nombre_personnes_à_charge - 6))
 ```
 
 ## Articles en vigueur à partir du 1er janvier 2023 - Arrêté du 26 décembre 2022 relatif au calcul des aides personnelles au logement pour l'année 2023 (NOR : TREL2226772A)


### PR DESCRIPTION
## Description

Cette PR corrige le forfait `R0` applicable à Saint-Pierre-et-Miquelon entre juillet et décembre 2022.

Pour chaque personne à charge au-delà de six, la formule utilisait une majoration de `350 €`, alors que le tableau réglementaire fixe cette majoration à `323 €`.

La valeur applicable à partir de janvier 2023 reste inchangée à `350 €`.

## Référence juridique

L’article 47 fixe une majoration de `323 €` par personne à charge supplémentaire pour la période concernée :

- [Article 47 — LEGIARTI000046126954](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046126954/2022-08-01)