### PR TITLE
[APL] Arrondit la CRDS au centime inférieur

### DIFF
--- a/aides_logement/autres_sources.catala_fr
+++ b/aides_logement/autres_sources.catala_fr
@@ -155,7 +155,14 @@ champ d'application ContributionsSocialesAidesPersonnelleLogement:
   définition montant de aide_finale
   sous condition date_courante >= |2018-09-01|
   conséquence égal à
-    aide_finale * taux_crds
+    # Voir brochure APL "Les aides personnelles au logement - Elements de calcul",
+    # edition avril 2023, page 59 (regles d'arrondi) :
+    # https://web.archive.org/web/20260518101631/https://www.ecologie.gouv.fr/sites/default/files/documents/Brochure-bareme-avril-2023-APL.pdf
+    soit crds_brut_décimal égal à aide_finale * taux_crds dans
+    soit crds_arrondi_centime_inf_décimal égal à
+      (arrondi de ((crds_brut_décimal * 100,0) - 0,5 €)) / 100,0
+    dans
+    crds_arrondi_centime_inf_décimal
 
   assertion exonéré_csg
 # Voir L136-1-3 code de la sécurité sociale


### PR DESCRIPTION
## Description

Cette PR applique explicitement l’arrondi de la CRDS au centime inférieur dans le calcul des aides personnelles au logement.

La CRDS était auparavant calculée directement avec :

`aide_finale * taux_crds`

Le calcul expose désormais le montant brut de CRDS puis applique l’arrondi au centime inférieur.

## Références juridiques et techniques

- [Article D. 823-16 du CCH](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878905) : décrit l’intégration des contributions sociales dans le calcul de l’aide.
- [Brochure APL d’avril 2024, page 59](https://web.archive.org/web/20260514102320/https://www.ecologie.gouv.fr/sites/default/files/documents/Brochure-bareme-2024-APL.pdf) : précise les règles d’arrondi.

La règle exacte d’arrondi au centime inférieur provient de la brochure technique.