### PR TITLE
[APL] Expose les étapes du calcul de l’aide nette

### DIFF
--- a/aides_logement/autres_sources.catala_fr
+++ b/aides_logement/autres_sources.catala_fr
@@ -413,9 +413,11 @@ champ d'application CalculAidePersonnaliséeLogementLocatif:
   définition traitement_aide_finale
     de aide_finale état montée_en_charge_saint_pierre_miquelon
   égal à
-    soit aide_finale égal à traitement_aide_finale de aide_finale dans
+    soit aide_finale_réduction_loyer_solidarité égal à
+      traitement_aide_finale de aide_finale
+    dans
     montée_en_charge_saint_pierre_miquelon de
-      aide_finale,
+      aide_finale_réduction_loyer_solidarité,
       résidence,
       date_courante
 

--- a/aides_logement/autres_sources.catala_fr
+++ b/aides_logement/autres_sources.catala_fr
@@ -292,7 +292,7 @@ champ d'application CalculetteAidesAuLogementGardeAlternée:
     # calculette_sans_garde_alternée.traitement_aide_finale ?
     calculette.traitement_aide_finale de
       (
-        calculette_sans_garde_alternée.aide_finale_formule
+        calculette_sans_garde_alternée.aide_finale_formule_initiale
         + (
           si nombre de coefficients_enfants_garde_alternée_pris_en_compte = 0 alors
             0 €
@@ -302,8 +302,8 @@ champ d'application CalculetteAidesAuLogementGardeAlternée:
             # période cumulée pendant laquelle le ménage accueille l'enfant
             # à domicile.
             (
-              calculette.aide_finale_formule
-              - calculette_sans_garde_alternée.aide_finale_formule
+              calculette.aide_finale_formule_initiale
+              - calculette_sans_garde_alternée.aide_finale_formule_initiale
             )
             * (
               (

--- a/aides_logement/code_construction_legislatif.catala_fr
+++ b/aides_logement/code_construction_legislatif.catala_fr
@@ -1156,7 +1156,7 @@ champ d'application CalculetteAidesAuLogement:
       TypeAidesPersonnelleLogement.AllocationLogementSociale
   )
 
-  définition aide_finale_formule égal à
+  définition aide_finale_formule_initiale égal à
     si non éligibilité alors 0 €
     sinon si
       éligibilité_aide_personnalisée_logement.éligibilité
@@ -1165,17 +1165,17 @@ champ d'application CalculetteAidesAuLogement:
       (
         si
           calcul_aide_personnalisée_logement.traitement_aide_finale de
-            calcul_aide_personnalisée_logement.aide_finale_formule
+            calcul_aide_personnalisée_logement.aide_finale_formule_initiale
           > calcul_allocation_logement.traitement_aide_finale de
-            calcul_allocation_logement.aide_finale_formule
+            calcul_allocation_logement.aide_finale_formule_initiale
         alors
-          calcul_aide_personnalisée_logement.aide_finale_formule
+          calcul_aide_personnalisée_logement.aide_finale_formule_initiale
         sinon
-          calcul_allocation_logement.aide_finale_formule
+          calcul_allocation_logement.aide_finale_formule_initiale
       )
     sinon si éligibilité_aide_personnalisée_logement.éligibilité alors
-      calcul_aide_personnalisée_logement.aide_finale_formule
-    sinon calcul_allocation_logement.aide_finale_formule
+      calcul_aide_personnalisée_logement.aide_finale_formule_initiale
+    sinon calcul_allocation_logement.aide_finale_formule_initiale
 
   définition traitement_aide_finale de aide_finale égal à
     soit aide_finale_apl égal à

--- a/aides_logement/code_construction_legislatif.catala_fr
+++ b/aides_logement/code_construction_legislatif.catala_fr
@@ -867,9 +867,16 @@ champ d'application CalculAidePersonnaliséeLogementLocatif:
   définition traitement_aide_finale
     de aide_finale état réduction_loyer_solidarité
   égal à
-    soit aide_finale égal à traitement_aide_finale de aide_finale dans
-    si aide_finale - réduction_loyer_solidarité * fraction_l832_3 >= 0€ alors
-      aide_finale - réduction_loyer_solidarité * fraction_l832_3
+    soit aide_finale_contributions_sociales_arrondi égal à
+      traitement_aide_finale de aide_finale
+    dans
+    si
+      aide_finale_contributions_sociales_arrondi
+      - réduction_loyer_solidarité * fraction_l832_3
+      >= 0€
+    alors
+      aide_finale_contributions_sociales_arrondi
+      - réduction_loyer_solidarité * fraction_l832_3
     sinon 0€
 
   assertion fraction_l832_3 >= 90% et fraction_l832_3 <= 98%

--- a/aides_logement/code_construction_reglementaire.catala_fr
+++ b/aides_logement/code_construction_reglementaire.catala_fr
@@ -1453,8 +1453,8 @@ champ d'application CalculAllocationLogement:
     -- LocationAccession contenu propriétaire :
       AccessionPropriété contenu propriétaire
 
-  définition aide_finale_formule égal à
-    sous_calcul_traitement.aide_finale_formule
+  définition aide_finale_formule_initiale égal à
+    sous_calcul_traitement.aide_finale_formule_initiale
   définition traitement_aide_finale de arg égal à
   (
     sous_calcul_traitement.
@@ -1474,8 +1474,8 @@ champ d'application CalculAidePersonnaliséeLogement:
     -- LocationAccession contenu propriétaire :
       AccessionPropriété contenu propriétaire
 
-  définition aide_finale_formule égal à
-    sous_calcul_traitement.aide_finale_formule
+  définition aide_finale_formule_initiale égal à
+    sous_calcul_traitement.aide_finale_formule_initiale
   définition traitement_aide_finale de arg égal à
   (
     sous_calcul_traitement.
@@ -1520,9 +1520,9 @@ champ d'application CalculAidePersonnaliséeLogement:
           }
         dans
         Traitement_formule_aide_finale {
-          -- aide_finale_formule:
+          -- aide_finale_formule_initiale:
             traitement_formule.
-              CalculAidePersonnaliséeLogementLocatif.aide_finale_formule
+              CalculAidePersonnaliséeLogementLocatif.aide_finale_formule_initiale
           -- traitement_aide_finale:
             traitement_formule.
               CalculAidePersonnaliséeLogementLocatif.traitement_aide_finale
@@ -1546,9 +1546,9 @@ champ d'application CalculAidePersonnaliséeLogement:
           }
         dans
         Traitement_formule_aide_finale {
-          -- aide_finale_formule:
+          -- aide_finale_formule_initiale:
             traitement_formule.
-              CalculAidePersonnaliséeLogementFoyer.aide_finale_formule
+              CalculAidePersonnaliséeLogementFoyer.aide_finale_formule_initiale
           -- traitement_aide_finale:
             traitement_formule.
               CalculAidePersonnaliséeLogementFoyer.traitement_aide_finale
@@ -1577,9 +1577,9 @@ champ d'application CalculAidePersonnaliséeLogement:
           }
         dans
         Traitement_formule_aide_finale {
-          -- aide_finale_formule:
+          -- aide_finale_formule_initiale:
             traitement_formule.
-              CalculAidePersonnaliséeLogementAccessionPropriété.aide_finale_formule
+              CalculAidePersonnaliséeLogementAccessionPropriété.aide_finale_formule_initiale
           -- traitement_aide_finale:
             traitement_formule.
               CalculAidePersonnaliséeLogementAccessionPropriété.traitement_aide_finale
@@ -1619,8 +1619,8 @@ champ d'application CalculAllocationLogement:
           }
         dans
         Traitement_formule_aide_finale {
-          -- aide_finale_formule:
-            traitement_formule.aide_finale_formule
+          -- aide_finale_formule_initiale:
+            traitement_formule.aide_finale_formule_initiale
           -- traitement_aide_finale:
             traitement_formule.
               CalculAllocationLogementLocatif.traitement_aide_finale
@@ -1646,8 +1646,8 @@ champ d'application CalculAllocationLogement:
           }
         dans
         Traitement_formule_aide_finale {
-          -- aide_finale_formule:
-            traitement_formule.aide_finale_formule
+          -- aide_finale_formule_initiale:
+            traitement_formule.aide_finale_formule_initiale
           -- traitement_aide_finale:
             traitement_formule.
               CalculAllocationLogementFoyer.traitement_aide_finale
@@ -1678,9 +1678,9 @@ champ d'application CalculAllocationLogement:
           }
         dans
         Traitement_formule_aide_finale {
-          -- aide_finale_formule:
+          -- aide_finale_formule_initiale:
             traitement_formule.
-              CalculAllocationLogementAccessionPropriété.aide_finale_formule
+              CalculAllocationLogementAccessionPropriété.aide_finale_formule_initiale
           -- traitement_aide_finale:
             traitement_formule.
               CalculAllocationLogementAccessionPropriété.traitement_aide_finale
@@ -1814,7 +1814,7 @@ $$\textrm{Af} = \textrm{L} + \textrm{C}-\textrm{Pp}$$
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif:
-  définition aide_finale_formule égal à
+  définition aide_finale_formule_initiale égal à
     soit aide_finale égal à
       loyer_éligible + montant_forfaitaire_charges_d823_16
       - participation_personnelle
@@ -1935,8 +1935,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif:
     sinon 0€
 
   # Expose explicitement l'intermédiaire pour les tests et explain.
-  définition aide_finale_nette_arrondie égal à
-    soit aide_brute égal à traitement_aide_finale de aide_finale_formule dans
+  définition aide_finale_après_traitement égal à
+    soit aide_brute égal à traitement_aide_finale de aide_finale_formule_initiale dans
     soit crds égal à contributions_sociales.montant de aide_brute dans
     soit aide_nette_arrondie égal à
       arrondi de ((aide_brute - crds) - 0,50€)
@@ -3168,7 +3168,7 @@ $$\textrm{Af} = \textrm{K} \times (\textrm{L} + \textrm{C}-\textrm{L0})$$
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété:
-  définition aide_finale_formule égal à
+  définition aide_finale_formule_initiale égal à
     soit aide_finale égal à
       (
         mensualité_éligible + montant_forfaitaire_charges_d832_10
@@ -3846,7 +3846,7 @@ $$\textrm{Af} = \textrm{K} \times (\textrm{E}-\textrm{E0})$$
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer:
-  définition aide_finale_formule égal à
+  définition aide_finale_formule_initiale égal à
     soit aide_finale égal à
       (équivalence_loyer_éligible - équivalence_loyer_minimale)
       * coefficient_prise_en_charge_d832_25
@@ -4406,7 +4406,8 @@ champ d'application CalculAllocationLogementLocatif:
     logement_meublé_d842_2
   définition calcul_apl_locatif.résidence égal à résidence
 
-  définition aide_finale_formule égal à calcul_apl_locatif.aide_finale_formule
+  définition aide_finale_formule_initiale égal à
+    calcul_apl_locatif.aide_finale_formule_initiale
   définition traitement_aide_finale de aide_finale égal à
     calcul_apl_locatif.traitement_aide_finale de aide_finale
 ```
@@ -4488,7 +4489,7 @@ sous condition
   -- PasDeChangement : faux:
 
   exception
-  définition aide_finale_formule égal à
+  définition aide_finale_formule_initiale égal à
     selon changement_logement_d842_4 sous forme
     -- Changement contenu infos :
       loyer_principal
@@ -4604,7 +4605,7 @@ $$\textrm{Af} = \textrm{K} \times (\textrm{L} + \textrm{C}-\textrm{L0})$$
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété:
-  définition aide_finale_formule égal à
+  définition aide_finale_formule_initiale égal à
     (
       mensualité_éligible + montant_forfaitaire_charges
       - mensualité_minimale
@@ -5033,7 +5034,7 @@ $$\textrm{Af} = \textrm{K} \times (\textrm{L} + \textrm{C}-\textrm{L0})$$
 
 ```catala
 champ d'application CalculAllocationLogementFoyer:
-  définition aide_finale_formule égal à
+  définition aide_finale_formule_initiale égal à
     (
       équivalence_loyer
       + montant_forfaitaire_charges
@@ -6870,8 +6871,8 @@ sous condition résidence sous forme SaintPierreEtMiquelon:
           }
         dans
         Traitement_formule_aide_finale {
-          -- aide_finale_formule:
-            traitement_formule.aide_finale_formule
+          -- aide_finale_formule_initiale:
+            traitement_formule.aide_finale_formule_initiale
           -- traitement_aide_finale:
             traitement_formule.
               CalculAllocationLogementLocatif.traitement_aide_finale
@@ -6881,12 +6882,12 @@ sous condition résidence sous forme SaintPierreEtMiquelon:
     # nous renvoyons des valeurs nulles qui ne seront jamais utilisées.
     -- AccessionPropriété :
       Traitement_formule_aide_finale {
-        -- aide_finale_formule: 0€
+        -- aide_finale_formule_initiale: 0€
         -- traitement_aide_finale: traitement_nul_tout_le_temps
       }
     -- Location :
       Traitement_formule_aide_finale {
-        -- aide_finale_formule: 0€
+        -- aide_finale_formule_initiale: 0€
         -- traitement_aide_finale: traitement_nul_tout_le_temps
       }
 

--- a/aides_logement/code_construction_reglementaire.catala_fr
+++ b/aides_logement/code_construction_reglementaire.catala_fr
@@ -1870,14 +1870,15 @@ champ d'application CalculAidePersonnaliséeLogementLocatif:
   définition traitement_aide_finale
     de aide_finale état diminué
   égal à
+    soit aide_finale_base égal à aide_finale dans
     si loyer_principal > plafond_suppression_d823_16 alors
       0€
     sinon
       (
         si loyer_principal > plafond_dégressivité_d823_16 alors
-          aide_finale
+          aide_finale_base
           - (
-            aide_finale
+            aide_finale_base
             * (
               (loyer_principal - plafond_dégressivité_d823_16)
               / (plafond_suppression_d823_16 - plafond_dégressivité_d823_16)
@@ -1885,7 +1886,7 @@ champ d'application CalculAidePersonnaliséeLogementLocatif:
           )
         # Faire un graphique pour se convaincre que la pente proportionnelle
         # a bien cette expression.
-        sinon aide_finale
+        sinon aide_finale_base
       )
 
   exception
@@ -1893,7 +1894,7 @@ champ d'application CalculAidePersonnaliséeLogementLocatif:
     de aide_finale état diminué
   sous condition bénéficiaire_aide_adulte_ou_enfant_handicapés
   conséquence égal à
-    aide_finale
+    soit aide_finale_base égal à aide_finale dans aide_finale_base
 
   assertion plafond_dégressivité_d823_16 >= plafond_loyer_d823_16_2 * 2,5
 ```
@@ -1905,9 +1906,9 @@ champ d'application CalculAidePersonnaliséeLogementLocatif:
   définition traitement_aide_finale
     de aide_finale état minoration_forfaitaire
   égal à
-    soit aide_finale égal à traitement_aide_finale de aide_finale dans
-    si aide_finale - montant_forfaitaire_d823_16 >= 0€ alors
-      aide_finale - montant_forfaitaire_d823_16
+    soit aide_finale_diminué égal à traitement_aide_finale de aide_finale dans
+    si aide_finale_diminué - montant_forfaitaire_d823_16 >= 0€ alors
+      aide_finale_diminué - montant_forfaitaire_d823_16
     sinon 0€
 ```
 
@@ -1920,16 +1921,27 @@ champ d'application CalculAidePersonnaliséeLogementLocatif:
   définition traitement_aide_finale
     de aide_finale état contributions_sociales_arrondi
   égal à
-    soit aide_finale égal à traitement_aide_finale de aide_finale dans
+    soit aide_finale_minoration_forfaitaire égal à
+      traitement_aide_finale de aide_finale
+    dans
     soit crds égal à
-      contributions_sociales.montant de aide_finale
+      contributions_sociales.montant de aide_finale_minoration_forfaitaire
     dans
     soit aide_finale_moins_crds_arrondie égal à
-      arrondi de ((aide_finale - crds) - 0,50€)
+      arrondi de ((aide_finale_minoration_forfaitaire - crds) - 0,50€)
     dans
     si aide_finale_moins_crds_arrondie + crds >= 0€ alors
       aide_finale_moins_crds_arrondie + crds
     sinon 0€
+
+  # Expose explicitement l'intermédiaire pour les tests et explain.
+  définition aide_finale_nette_arrondie égal à
+    soit aide_brute égal à traitement_aide_finale de aide_finale_formule dans
+    soit crds égal à contributions_sociales.montant de aide_brute dans
+    soit aide_nette_arrondie égal à
+      arrondi de ((aide_brute - crds) - 0,50€)
+    dans
+    si aide_nette_arrondie >= 0€ alors aide_nette_arrondie sinon 0€
 ```
 
 Pour les locataires qui bénéficient de la réduction de loyer de solidarité en application
@@ -1950,10 +1962,15 @@ champ d'application CalculAidePersonnaliséeLogementLocatif:
   définition traitement_aide_finale
     de aide_finale état montant_minimal
   égal à
-    soit aide_finale égal à traitement_aide_finale de aide_finale dans
-    si aide_finale < montant_minimal_aide_d823_16 alors
+    soit aide_finale_montée_en_charge_saint_pierre_miquelon égal à
+      traitement_aide_finale de aide_finale
+    dans
+    si
+      aide_finale_montée_en_charge_saint_pierre_miquelon
+      < montant_minimal_aide_d823_16
+    alors
       0 €
-    sinon aide_finale
+    sinon aide_finale_montée_en_charge_saint_pierre_miquelon
 ```
 
 ######## Article D823-17 | LEGIARTI000041419255

--- a/aides_logement/prologue.catala_fr
+++ b/aides_logement/prologue.catala_fr
@@ -568,8 +568,8 @@ déclaration champ d'application CalculAidePersonnaliséeLogementLocatif:
   contributions_sociales
     champ d'application ContributionsSocialesAidesPersonnelleLogement
 
-  résultat aide_finale_formule contenu argent
-  résultat aide_finale_nette_arrondie contenu argent
+  résultat aide_finale_formule_initiale contenu argent
+  résultat aide_finale_après_traitement contenu argent
 
   résultat traitement_aide_finale contenu argent
   dépend de aide_finale contenu argent état diminué
@@ -670,7 +670,7 @@ déclaration champ d'application CalculAidePersonnaliséeLogementFoyer:
     état coeff_arrondi
     état seuil
 
-  résultat aide_finale_formule contenu argent
+  résultat aide_finale_formule_initiale contenu argent
   résultat traitement_aide_finale contenu argent
   dépend de aide_finale contenu argent état minoration_forfaitaire
     état abattement
@@ -747,7 +747,7 @@ déclaration champ d'application CalculAidePersonnaliséeLogementAccessionPropri
   contributions_sociales
     champ d'application ContributionsSocialesAidesPersonnelleLogement
 
-  résultat aide_finale_formule contenu argent
+  résultat aide_finale_formule_initiale contenu argent
   résultat traitement_aide_finale contenu argent
   dépend de aide_finale contenu argent état minoration_forfaitaire
     état abattement
@@ -768,7 +768,7 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété:
 
 ```catala-metadata
 déclaration structure Traitement_formule_aide_finale:
-  donnée aide_finale_formule contenu argent
+  donnée aide_finale_formule_initiale contenu argent
   donnée traitement_aide_finale
         contenu argent dépend de aide_finale contenu argent
 
@@ -789,7 +789,7 @@ déclaration champ d'application CalculAidePersonnaliséeLogement:
 
   interne sous_calcul_traitement contenu Traitement_formule_aide_finale
 
-  résultat aide_finale_formule contenu argent
+  résultat aide_finale_formule_initiale contenu argent
   résultat traitement_aide_finale
     contenu argent dépend de arg contenu argent
 ```
@@ -831,7 +831,7 @@ déclaration champ d'application CalculAllocationLogementLocatif:
 
   calcul_apl_locatif champ d'application CalculAidePersonnaliséeLogementLocatif
 
-  résultat aide_finale_formule contenu argent
+  résultat aide_finale_formule_initiale contenu argent
   résultat traitement_aide_finale
     contenu argent dépend de aide_finale contenu argent
   résultat montant_forfaitaire_charges_d823_16 contenu argent
@@ -911,7 +911,7 @@ déclaration champ d'application CalculAllocationLogementAccessionPropriété:
   calcul_équivalence_loyer_minimale
     champ d'application CalculÉquivalenceLoyerMinimale
 
-  résultat aide_finale_formule contenu argent
+  résultat aide_finale_formule_initiale contenu argent
 
   résultat traitement_aide_finale contenu argent
   dépend de aide_finale contenu argent état minoration_forfaitaire
@@ -1006,7 +1006,7 @@ déclaration champ d'application CalculAllocationLogementFoyer:
   calcul_équivalence_loyer_minimale
     champ d'application CalculÉquivalenceLoyerMinimale
 
-  résultat aide_finale_formule contenu argent
+  résultat aide_finale_formule_initiale contenu argent
   résultat traitement_aide_finale contenu argent
   dépend de aide_finale contenu argent état minoration_forfaitaire
     état dépense_nette_minimale
@@ -1070,7 +1070,7 @@ déclaration champ d'application CalculAllocationLogement:
 
   interne sous_calcul_traitement contenu Traitement_formule_aide_finale
 
-  résultat aide_finale_formule contenu argent
+  résultat aide_finale_formule_initiale contenu argent
   résultat traitement_aide_finale
     contenu argent dépend de arg contenu argent
 ```
@@ -1135,7 +1135,7 @@ déclaration champ d'application CalculetteAidesAuLogement:
     champ d'application CalculAllocationLogement
 
   résultat éligibilité contenu booléen
-  résultat aide_finale_formule contenu argent
+  résultat aide_finale_formule_initiale contenu argent
   résultat traitement_aide_finale
     contenu argent dépend de aide_finale contenu argent
   résultat coefficients_enfants_garde_alternée_pris_en_compte

--- a/aides_logement/prologue.catala_fr
+++ b/aides_logement/prologue.catala_fr
@@ -569,6 +569,7 @@ déclaration champ d'application CalculAidePersonnaliséeLogementLocatif:
     champ d'application ContributionsSocialesAidesPersonnelleLogement
 
   résultat aide_finale_formule contenu argent
+  résultat aide_finale_nette_arrondie contenu argent
 
   résultat traitement_aide_finale contenu argent
   dépend de aide_finale contenu argent état diminué

--- a/aides_logement/tests/tests_calcul_al_accession_propriete.catala_fr
+++ b/aides_logement/tests/tests_calcul_al_accession_propriete.catala_fr
@@ -32,12 +32,12 @@ champ d'application Exemple1:
 
   définition montant égal à
     calcul.traitement_aide_finale de
-      calcul.aide_finale_formule
+      calcul.aide_finale_formule_initiale
   assertion montant = 96,48 €
   assertion calcul.mensualité_éligible = 375,2 €
   assertion calcul.mensualité_minimale = 267,90 €
   assertion calcul.coefficient_prise_en_charge = 0,62
-  assertion calcul.aide_finale_formule = 101,90€
+  assertion calcul.aide_finale_formule_initiale = 101,90€
 ```
 
 ```catala
@@ -67,11 +67,11 @@ champ d'application Exemple2:
 
   définition montant égal à
     calcul.traitement_aide_finale de
-      calcul.aide_finale_formule
+      calcul.aide_finale_formule_initiale
   assertion calcul.mensualité_éligible = 405,10 €
   assertion calcul.mensualité_minimale = 296,96 €
   assertion calcul.coefficient_prise_en_charge = 0,66
-  assertion calcul.aide_finale_formule = 141,99€
+  assertion calcul.aide_finale_formule_initiale = 141,99€
   assertion montant = 85,00 €
 ```
 

--- a/aides_logement/tests/tests_calcul_al_locatif.catala_fr
+++ b/aides_logement/tests/tests_calcul_al_locatif.catala_fr
@@ -32,7 +32,7 @@ champ d'application Exemple1:
   définition calcul.logement_meublé_d842_2 égal à faux
   définition calcul.changement_logement_d842_4 égal à PasDeChangement
   définition montant égal à
-    calcul.traitement_aide_finale de calcul.aide_finale_formule
+    calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   # Attention dans cet exemple le taux de loyer éligible est bien arrondi à
   # la troisième décimale en pourcentage comme le dit bien le 2° de l'article
   # 14 de l'arrêté du 27 septembre 2019, et non à la deuxième décimale comme le
@@ -66,7 +66,7 @@ champ d'application Exemple2:
   définition calcul.logement_meublé_d842_2 égal à faux
   définition calcul.changement_logement_d842_4 égal à PasDeChangement
   définition montant égal à
-    calcul.traitement_aide_finale de calcul.aide_finale_formule
+    calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   assertion montant = 352,77€
 
 # Exemple aux DROM
@@ -96,7 +96,7 @@ champ d'application Exemple3:
   définition calcul.logement_meublé_d842_2 égal à faux
   définition calcul.changement_logement_d842_4 égal à PasDeChangement
   définition montant égal à
-    calcul.traitement_aide_finale de calcul.aide_finale_formule
+    calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   assertion montant = 339,70€
 ```
 
@@ -128,7 +128,7 @@ champ d'application Exemple4:
   définition calcul.logement_meublé_d842_2 égal à faux
   définition calcul.changement_logement_d842_4 égal à PasDeChangement
   définition montant égal à
-    calcul.traitement_aide_finale de calcul.aide_finale_formule
+    calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
 
   assertion calcul.montant_forfaitaire_charges_d823_16 = 81,56 €
   assertion calcul.plafond_loyer_d823_16_2 = 424,22 €

--- a/aides_logement/tests/tests_calcul_al_logement_foyer.catala_fr
+++ b/aides_logement/tests/tests_calcul_al_logement_foyer.catala_fr
@@ -29,7 +29,7 @@ champ d'application CasTest1:
   assertion calcul.coefficient_prise_en_charge = 0,6
   définition montant égal à
     calcul.traitement_aide_finale de
-      calcul.aide_finale_formule
+      calcul.aide_finale_formule_initiale
   assertion montant = 76,38 €
 ```
 

--- a/aides_logement/tests/tests_calcul_apl_accession_propriete.catala_fr
+++ b/aides_logement/tests/tests_calcul_apl_accession_propriete.catala_fr
@@ -32,12 +32,12 @@ champ d'application Exemple1:
 
   définition montant égal à
     calcul.traitement_aide_finale de
-      calcul.aide_finale_formule
+      calcul.aide_finale_formule_initiale
   assertion montant = 181,91 €
   assertion calcul.mensualité_éligible = 533,91 €
   assertion calcul.mensualité_minimale = 332,76 €
   assertion calcul.coefficient_prise_en_charge_d832_10 = 0,67
-  assertion calcul.aide_finale_formule = 187,35€
+  assertion calcul.aide_finale_formule_initiale = 187,35€
 ```
 
 ```catala
@@ -72,12 +72,12 @@ champ d'application Exemple2:
   # par le 18° b° de l'article 18 de l'arrêté du 27 septembre 2019, et non
   # par le 18° a). Ce qui donne une mensualité éligible de 399,20 € et non
   # de 495,73 €.
-  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
+  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   assertion montant = 67,34 €
   assertion calcul.mensualité_éligible = 399,20 €
   assertion calcul.mensualité_minimale = 367,42 €
   assertion calcul.coefficient_prise_en_charge_d832_10 = 0,66
-  assertion calcul.aide_finale_formule = 72,77€
+  assertion calcul.aide_finale_formule_initiale = 72,77€
 ```
 
 ```catala
@@ -108,12 +108,12 @@ champ d'application Exemple3:
 
   définition montant égal à
     calcul.traitement_aide_finale de
-      calcul.aide_finale_formule
+      calcul.aide_finale_formule_initiale
   assertion montant = 181,91 €
   assertion calcul.mensualité_éligible = 533,91 €
   assertion calcul.mensualité_minimale = 332,76 €
   assertion calcul.coefficient_prise_en_charge_d832_10 = 0,67
-  assertion calcul.aide_finale_formule = 187,57€
+  assertion calcul.aide_finale_formule_initiale = 187,57€
 ```
 
 ```catala
@@ -144,12 +144,12 @@ champ d'application Exemple4:
 
   définition montant égal à
     calcul.traitement_aide_finale de
-      calcul.aide_finale_formule
+      calcul.aide_finale_formule_initiale
   assertion montant = 118,59 €
   assertion calcul.mensualité_éligible = 399,20 €
   assertion calcul.mensualité_minimale = 290,21 €
   assertion calcul.coefficient_prise_en_charge_d832_10 = 0,66
-  assertion calcul.aide_finale_formule = 123,94 €
+  assertion calcul.aide_finale_formule_initiale = 123,94 €
 ```
 
 ```catala-test-cli

--- a/aides_logement/tests/tests_calcul_apl_locatif.catala_fr
+++ b/aides_logement/tests/tests_calcul_apl_locatif.catala_fr
@@ -10,7 +10,7 @@ déclaration champ d'application Exemple1:
   résultat montant contenu argent
 
 champ d'application Exemple1:
-  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
+  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   définition calcul.loyer_principal égal à 700 €
   définition calcul.date_courante égal à |2022-02-03|
   définition calcul.logement_est_chambre égal à faux
@@ -43,7 +43,7 @@ déclaration champ d'application Exemple2:
   résultat montant contenu argent
 
 champ d'application Exemple2:
-  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
+  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   définition calcul.loyer_principal égal à 425 €
   définition calcul.date_courante égal à |2022-04-03|
   définition calcul.logement_est_chambre égal à faux
@@ -76,7 +76,7 @@ déclaration champ d'application Exemple3:
   résultat montant contenu argent
 
 champ d'application Exemple3:
-  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
+  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   définition calcul.loyer_principal égal à 408 €
   définition calcul.date_courante égal à |2022-01-18|
   définition calcul.logement_est_chambre égal à faux
@@ -109,7 +109,7 @@ déclaration champ d'application Exemple4:
   résultat montant contenu argent
 
 champ d'application Exemple4:
-  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
+  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   définition calcul.loyer_principal égal à 680 €
   définition calcul.date_courante égal à |2022-02-19|
   définition calcul.logement_est_chambre égal à faux
@@ -142,7 +142,7 @@ déclaration champ d'application Exemple5:
   résultat montant contenu argent
 
 champ d'application Exemple5:
-  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
+  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   définition calcul.loyer_principal égal à 610 €
   définition calcul.date_courante égal à |2022-04-05|
   définition calcul.logement_est_chambre égal à faux
@@ -175,7 +175,7 @@ déclaration champ d'application Exemple6:
   résultat montant contenu argent
 
 champ d'application Exemple6:
-  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
+  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   définition calcul.loyer_principal égal à 436 €
   définition calcul.date_courante égal à |2022-05-02|
   définition calcul.logement_est_chambre égal à faux
@@ -208,7 +208,7 @@ déclaration champ d'application Exemple7:
   résultat montant contenu argent
 
 champ d'application Exemple7:
-  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
+  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   définition calcul.loyer_principal égal à 527 €
   définition calcul.date_courante égal à |2022-02-13|
   définition calcul.logement_est_chambre égal à faux
@@ -241,7 +241,7 @@ déclaration champ d'application Exemple8:
   résultat montant contenu argent
 
 champ d'application Exemple8:
-  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
+  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   définition calcul.loyer_principal égal à 310 €
   définition calcul.date_courante égal à |2022-04-02|
   définition calcul.logement_est_chambre égal à vrai
@@ -276,7 +276,7 @@ déclaration champ d'application Exemple9:
 champ d'application Exemple9:
   définition montant égal à
     calcul.traitement_aide_finale de
-      calcul.aide_finale_formule
+      calcul.aide_finale_formule_initiale
   définition calcul.loyer_principal égal à 400 €
   définition calcul.date_courante égal à |2022-06-10|
   définition calcul.logement_est_chambre égal à faux

--- a/aides_logement/tests/tests_calcul_apl_logement_foyer.catala_fr
+++ b/aides_logement/tests/tests_calcul_apl_logement_foyer.catala_fr
@@ -26,7 +26,7 @@ champ d'application CasTest1:
   assertion calcul.coefficient_prise_en_charge_d832_25 = 0,41
   assertion calcul.plafond_équivalence_loyer_éligible = 450,57 €
   assertion calcul.équivalence_loyer_minimale = 318,13 €
-  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
+  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   assertion montant = 12,06 €
 
 #[test]
@@ -53,7 +53,7 @@ champ d'application CasTest2:
   assertion calcul.coefficient_prise_en_charge = 0,43
   définition montant égal à
     calcul.traitement_aide_finale de
-      calcul.aide_finale_formule
+      calcul.aide_finale_formule_initiale
   assertion montant = 23,12 €
 ```
 
@@ -80,7 +80,7 @@ champ d'application CasTest3:
   assertion calcul.plafond_équivalence_loyer_éligible = 444,43€
   assertion calcul.équivalence_loyer_minimale = 98,95 €
   assertion calcul.coefficient_prise_en_charge_d832_25 = 0,64
-  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
+  définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule_initiale
   assertion montant = 154,78 €
 ```
 
@@ -108,7 +108,7 @@ champ d'application CasTest4:
   assertion calcul.coefficient_prise_en_charge_d832_25 = 0,64
   définition montant égal à
     calcul.traitement_aide_finale de
-      calcul.aide_finale_formule
+      calcul.aide_finale_formule_initiale
   assertion montant = 154,78 €
 ```
 
@@ -137,7 +137,7 @@ champ d'application CasTest5:
   assertion calcul.coefficient_prise_en_charge_d832_25 = 0,6
   définition montant égal à
     calcul.traitement_aide_finale de
-      calcul.aide_finale_formule
+      calcul.aide_finale_formule_initiale
   assertion montant = 129,65 €
 ```
 

--- a/aides_logement/tests/tests_couverture_temporelle.catala_fr
+++ b/aides_logement/tests/tests_couverture_temporelle.catala_fr
@@ -43,7 +43,7 @@ champ d'application CouvertureAPLLocatifMétropole:
           -- logement_meublé_d842_2: faux
           -- résidence: France.Collectivité.Métropole
         }
-      ).aide_finale_formule
+      ).aide_finale_formule_initiale
 ```
 
 ## APL locatif — résidence en Métropole, avec colocation
@@ -77,7 +77,7 @@ champ d'application CouvertureAPLLocatifColocation:
           -- logement_meublé_d842_2: faux
           -- résidence: France.Collectivité.Métropole
         }
-      ).aide_finale_formule
+      ).aide_finale_formule_initiale
 ```
 
 ## APL locatif — résidence dans les DROM
@@ -111,5 +111,5 @@ champ d'application CouvertureAPLLocatifDROM:
           -- logement_meublé_d842_2: faux
           -- résidence: France.Collectivité.Guadeloupe
         }
-      ).aide_finale_formule
+      ).aide_finale_formule_initiale
 ```


### PR DESCRIPTION
## Description

Cette PR nomme explicitement les différentes étapes du calcul de l’aide nette afin de rendre le résultat de `catala explain` plus clair.

Elle expose notamment l’intermédiaire `aide_finale_nette_arrondie`.

Cette modification vise uniquement à faciliter la lecture et le debug du calcul. Elle ne change pas le montant final de l’aide.