### PR TITLE
[APL] Correction valeur R0 2 PAC 2022

### DIFF
--- a/aides_logement/archives.catala_fr
+++ b/aides_logement/archives.catala_fr
@@ -1674,7 +1674,7 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     sinon si nombre_personnes_à_charge = 1 alors
       8 002 €
     sinon si nombre_personnes_à_charge = 2 alors
-      8 192 €
+      8 182 €
     sinon si nombre_personnes_à_charge = 3 alors
       8 495 €
     sinon si nombre_personnes_à_charge = 4 alors

--- a/aides_logement/tests/tests_calcul_apl_locatif.catala_fr
+++ b/aides_logement/tests/tests_calcul_apl_locatif.catala_fr
@@ -60,7 +60,7 @@ champ d'application Exemple2:
   assertion calcul.plafond_loyer_d823_16_2 = 409,88 €
   assertion calcul.participation_minimale = 41,54 €
   assertion calcul.taux_composition_familiale = 2,38%
-  assertion calcul.participation_personnelle = 130,36 €
+  assertion calcul.participation_personnelle = 130,63 €
 ```
 
 ```catala


### PR DESCRIPTION
## Description

Cette PR corrige une incohérence dans le barème `R0` applicable en outre-mer pour les aides personnelles au logement entre le 1er janvier 2022 et le 30 juin 2022.

## Source juridique

Arrêté du 20 décembre 2021 relatif au calcul des aides personnelles au logement pour l'année 2022 :  
https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819

## Correction apportée

Dans la règle `abattement_forfaitaire_d823_17` applicable du `2022-01-01` au `2022-07-01`, la valeur :
- `8 192 €`

est remplacée par :
- `8 182 €`

pour le cas :
- `nombre_personnes_à_charge = 2`