### PR TITLE
[APL] Ajoute la condition de colocation au forfait de charges DOM dans les archives

### DIFF
--- a/aides_logement/archives.catala_fr
+++ b/aides_logement/archives.catala_fr
@@ -3432,17 +3432,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception colocation_métropole
   définition montant_forfaitaire_charges_d823_16
-  sous condition (
-    selon résidence sous forme
-    -- Guadeloupe : vrai
-    -- Guyane : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
-  )
+  sous condition
+    (
+      selon résidence sous forme
+      -- Guadeloupe : vrai
+      -- Martinique : vrai
+      -- Guyane : vrai
+      -- LaRéunion : vrai
+      -- Mayotte : vrai
+      -- SaintBarthélemy : vrai
+      -- SaintMartin : vrai
+      -- n'importe quel : faux
+    )
+    et colocation
   conséquence égal à
     soit montant égal à
       (
@@ -4130,17 +4132,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   exception colocation_métropole
   définition montant_forfaitaire_charges_d823_16
-  sous condition (
-    selon résidence sous forme
-    -- Guadeloupe : vrai
-    -- Guyane : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
-  )
+  sous condition
+    (
+      selon résidence sous forme
+      -- Guadeloupe : vrai
+      -- Martinique : vrai
+      -- Guyane : vrai
+      -- LaRéunion : vrai
+      -- Mayotte : vrai
+      -- SaintBarthélemy : vrai
+      -- SaintMartin : vrai
+      -- n'importe quel : faux
+    )
+    et colocation
   conséquence égal à
     soit montant égal à
       (
@@ -5393,17 +5397,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   exception colocation_métropole
   définition montant_forfaitaire_charges_d823_16
-  sous condition (
-    selon résidence sous forme
-    -- Guadeloupe : vrai
-    -- Guyane : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
-  )
+  sous condition
+    (
+      selon résidence sous forme
+      -- Guadeloupe : vrai
+      -- Martinique : vrai
+      -- Guyane : vrai
+      -- LaRéunion : vrai
+      -- Mayotte : vrai
+      -- SaintBarthélemy : vrai
+      -- SaintMartin : vrai
+      -- n'importe quel : faux
+    )
+    et colocation
   conséquence égal à
     soit montant égal à
       (
@@ -6623,17 +6629,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   exception colocation_métropole
   définition montant_forfaitaire_charges_d823_16
-  sous condition (
-    selon résidence sous forme
-    -- Guadeloupe : vrai
-    -- Guyane : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
-  )
+  sous condition
+    (
+      selon résidence sous forme
+      -- Guadeloupe : vrai
+      -- Guyane : vrai
+      -- Martinique : vrai
+      -- LaRéunion : vrai
+      -- Mayotte : vrai
+      -- SaintBarthélemy : vrai
+      -- SaintMartin : vrai
+      -- n'importe quel : faux
+    )
+    et colocation
   conséquence égal à
     soit montant égal à
       (
@@ -7241,17 +7249,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   exception colocation_métropole
   définition montant_forfaitaire_charges_d823_16
-  sous condition (
-    selon résidence sous forme
-    -- Guadeloupe : vrai
-    -- Guyane : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
-  )
+  sous condition
+    (
+      selon résidence sous forme
+      -- Guadeloupe : vrai
+      -- Guyane : vrai
+      -- Martinique : vrai
+      -- LaRéunion : vrai
+      -- Mayotte : vrai
+      -- SaintBarthélemy : vrai
+      -- SaintMartin : vrai
+      -- n'importe quel : faux
+    )
+    et colocation
   conséquence égal à
     soit montant égal à
       (


### PR DESCRIPTION
## Description

Cette PR applique dans les archives une correction déjà présente dans le cas actuel : le forfait de charges spécifique aux colocataires en outre-mer doit être appliqué uniquement lorsque `colocation = vrai`.

Le `b` du `3°` de l'article `46` de l'arrêté du 27 septembre 2019 vise explicitement les montants applicables aux colocataires. Cette condition devait donc aussi être présente dans les versions archivées du barème.

## Source juridique

Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement, article 46, 3° b :  
https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2022-08-30/

## Correction apportée

Ajout de la condition `colocation` dans les règles archivées qui définissent le forfait de charges DOM spécifique aux colocataires.

## Impact

Cette correction évite d'appliquer le barème colocataire :
- à des logements ordinaires
- dans les versions archivées du calcul

Elle aligne les archives sur la logique déjà appliquée dans la version actuelle.